### PR TITLE
Add self-hosted HedgeDoc documentation

### DIFF
--- a/selfhosted/README.md
+++ b/selfhosted/README.md
@@ -1,0 +1,18 @@
+HedgeDoc ఒక open-source collaborative Markdown editor. ఇది self-hosting ద్వారా వినియోగదారులకు తమ స్వంత డేటాపై పూర్తి నియంత్రణను ఇస్తుంది. ఈ ప్రాజెక్ట్‌లో నేను HedgeDoc ను Docker ఉపయోగించి నా స్థానిక సిస్టమ్‌లో స్వయంగా హోస్ట్ చేసి, దాని ముఖ్య ఫీచర్లు మరియు ఉపయోగించే విధానాన్ని చూపించే ఒక demonstration video ను రూపొందించాను.
+
+HedgeDoc ను రన్ చేయడానికి Git, Docker మరియు Docker Compose అవసరం. ముందుగా రిపోజిటరీని క్లోన్ చేయాలి:
+
+git clone https://github.com/2400030343SameerReddy/Y24OpenSourceEngineering.git  
+cd Y24OpenSourceEngineering
+
+తర్వాత Docker ద్వారా సర్వర్ ప్రారంభించాలి:
+
+docker compose up -d
+
+సర్వర్ ప్రారంభమైన తర్వాత బ్రౌజర్ లో http://localhost:3000 ఓపెన్ చేసి HedgeDoc ను ఉపయోగించవచ్చు.
+
+Self-hosted HedgeDoc demo video (Google Drive): [Paste your Google Drive link here]
+
+LinkedIn Post: https://www.linkedin.com/pulse/building-learning-sharing-my-open-source-journey-gurala-4hqze
+
+Team Members: Sameer Reddy, Eswar


### PR DESCRIPTION
This Pull Request adds the selfhosted/README.md file containing the complete documentation for the self-hosted HedgeDoc project. 
The file includes a professional overview, installation steps, Google Drive demo video link placeholder, LinkedIn post link, and team member details (Sameer Reddy and Eswar). 
This submission is made as part of Issue #73 in the Y24 Open Source Engineering repository.
